### PR TITLE
JOSS review 1

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -319,7 +319,7 @@
 }
 
 @article{ramadhan2020oceananigans,
-  title={Oceananigans. jl: {F}ast and friendly geophysical fluid dynamics
+  title={Oceananigans.jl: {F}ast and friendly geophysical fluid dynamics
          on GPUs},
   author={Ramadhan, Ali and Wagner, Gregory LeClaire and Hill, Chris and
           Campin, Jean-Michel and Churavy, Valentin and Besard, Tim and

--- a/paper.md
+++ b/paper.md
@@ -132,7 +132,7 @@ du = D * u
 integrate(u -> u^2, du - pi * cospi.(x), D) |> sqrt
 ```
 The output of the last command will be a relatively small number on the order of
-`4.2-13`.
+`4.2e-13`.
 
 Following good software development practices, SummationByPartsOperators.jl
 makes use of continuous integration and automated tests required before merging

--- a/paper.md
+++ b/paper.md
@@ -68,7 +68,7 @@ of this package. In addition, SummationByPartsOperators.jl has been used in a
 number of graduate-level numerical analysis courses, allowing students to
 understand the connections between different SBP methods by presenting them in
 a unified framework. In addition, some of the operators were not available in
-open source software previously (to the author's knowledge).
+open source software previously (to the best of the author's knowledge).
 
 
 # Features

--- a/paper.md
+++ b/paper.md
@@ -62,7 +62,8 @@ methods for PDEs.
 SummationByPartsOperators.jl is written entirely in Julia [@bezanson2017julia].
 Making use of multiple dispatch and generic types, SummationByPartsOperators.jl
 provides a unified interface for different SBP operators. At the same time,
-the implementations are reasonably fast. Together, this facilitates the development
+the implementations are reasonably fast (again, due to multiple dispatch and specialized
+implementations for each operator class). Together, this facilitates the development
 of new algorithms and research in numerical analysis, which is the primary goal
 of this package. In addition, SummationByPartsOperators.jl has been used in a
 number of graduate-level numerical analysis courses, allowing students to

--- a/paper.md
+++ b/paper.md
@@ -111,19 +111,26 @@ SummationByPartsOperators.jl. In contrast, the same operation takes roughly
 this operator [@almquist2017optimized]. This benchmark is based on the following
 code, which also provides a very basic example of SummationByPartsOperators.jl.
 ```julia
-julia> using Pkg; Pkg.add("SummationByPartsOperators") # if not installed previously
+julia> # install the package if necessary
+       using Pkg; Pkg.add("SummationByPartsOperators")
 
 julia> using SummationByPartsOperators # load the package
 
-julia> D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(), derivative_order=1,
-                               accuracy_order=6, xmin=0.0, xmax=1.0, N=10^3)
+julia> # create a finite difference SBP operator
+       D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(),
+          derivative_order=1, accuracy_order=6, xmin=0.0, xmax=1.0, N=10^3)
+SBP first-derivative operator of order 6 on a grid in [0.0, 1.0] using 1000 nodes
+and coefficients of Mattsson, Almquist, van der Weide (2018)
+  Boundary optimized diagonal-norm SBP operators ('Accurate').
+  Journal of Computational Physics 374, pp. 1261-1266.
 
-julia> x = grid(D); u = sinpi.(x); # evaluate the function `sinpi` on the discrete grid
+julia> # evaluate the function `sinpi` on the discrete grid
+       x = grid(D); u = sinpi.(x);
 
-julia> du = D * u; # evaluate the discrete derivative of `u` using the SBP operator `D`
+julia> du = D * u; # use `D` to approximate the derivative of `u`
 
-julia> integrate(u -> u^2,
-         du - pi * cospi.(x), D) |> sqrt # compute the discrete L² error of the approximation
+julia> # compute the discrete L² error of the approximation
+       integrate(u -> u^2, du - pi * cospi.(x), D) |> sqrt
 4.238102975456189e-13
 ```
 

--- a/paper.md
+++ b/paper.md
@@ -124,13 +124,13 @@ numerical methods or a specific application, e.g.,
 
 - finite difference methods ([DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl),
   a part of DifferentialEquations.jl [@rackauckas2017differentialequations])
-- finite volume methods (Oceananigans.jl [@ramadhan2020oceananigans],
-  Kinetic.jl [@xiao2021kinetic])
-- spectral methods (ApproxFun.jl [@olver2014practical],
-  FourierFlows.jl [@constantinou2021fourierflows])
-- finite element methods (Gridap.jl [@badia2020gridap])
+- finite volume methods ([Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl) [@ramadhan2020oceananigans],
+  [Kinetic.jl](https://github.com/vavrines/Kinetic.jl) [@xiao2021kinetic])
+- spectral methods ([ApproxFun.jl](https://github.com/JuliaApproximation/ApproxFun.jl) [@olver2014practical],
+  [FourierFlows.jl](https://github.com/FourierFlows/FourierFlows.jl) [@constantinou2021fourierflows])
+- finite element methods ([Gridap.jl](https://github.com/gridap/Gridap.jl) [@badia2020gridap])
 - discontinuous spectral element methods
-  (Trixi.jl [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
+  ([Trixi.jl](https://github.com/trixi-framework/Trixi.jl) [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
 
 We are not aware of any open-source software library implementing all of the
 SBP classes using a unified interface or even several finite difference

--- a/paper.md
+++ b/paper.md
@@ -119,8 +119,9 @@ using SummationByPartsOperators
 
 # create a finite difference SBP operator
 D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(),
-                        derivative_order=1, accuracy_order=6,
-                        xmin=0.0, xmax=1.0, N=10^3)
+  derivative_order=1, accuracy_order=6,
+  xmin=0.0, xmax=1.0, N=10^3
+)
 
 # evaluate the function `sinpi` on the discrete grid
 x = grid(D); u = sinpi.(x)

--- a/paper.md
+++ b/paper.md
@@ -123,7 +123,7 @@ julia> x = grid(D); u = sinpi.(x); # evaluate the function `sinpi` on the discre
 julia> du = D * u; # evaluate the discrete derivative of `u` using the SBP operator `D`
 
 julia> integrate(u -> u^2,
-         du - π * cospi.(x), D) |> sqrt # compute the discrete L² error of the approximation
+         du - pi * cospi.(x), D) |> sqrt # compute the discrete L² error of the approximation
 4.238102975456189e-13
 ```
 

--- a/paper.md
+++ b/paper.md
@@ -16,7 +16,7 @@ authors:
 affiliations:
  - name: Applied Mathematics Münster, University of Münster, Germany
    index: 1
-date: 25 May 2021
+date: 19 July 2021
 bibliography: paper.bib
 ---
 
@@ -41,8 +41,12 @@ sacrificing flexibility.
 
 Partial differential equations (PDEs) are widely used in science and engineering
 to create mathematical models of real-world processes. Since PDEs often need to
-be solved numerically, a vast amount of numerical methods has been developed,
-resulting sometimes in completely disjoint communities. To transfer developments
+be solved numerically, a vast amount of numerical methods has been developed.
+Since it is impossible to keep up with all recent research, sub-communities
+focussing on specific applications or numerical methods emerged. Sometimes,
+these communities develop different vocabulary and notations, making it hard for
+newcomers (or even experienced researchers) to see similarities and connections
+between seemingly unrelated approaches. To transfer new ideas and developments
 and knowledge from one community to another, common abstractions can be helpful.
 The concept of SBP operators is such an abstraction.
 In recent years, SBP operators have attracted a lot of attention, in particular
@@ -61,7 +65,10 @@ provides a unified interface for different SBP operators. At the same time,
 the implementations are reasonably fast. Together, this facilitates the development
 of new algorithms and research in numerical analysis, which is the primary goal
 of this package. In addition, SummationByPartsOperators.jl has been used in a
-number of graduate-level numerical analysis courses.
+number of graduate-level numerical analysis courses, allowing students to
+understand the connections between different SBP methods by presenting them in
+a unified framework. In addition, some of the operators were not available in
+open source software previously (to the author's knowledge).
 
 
 # Features
@@ -74,7 +81,7 @@ of the following classes:
 - continuous Galerkin methods
 - discontinuous Galerkin methods
 
-Since a discrete derivative operator is basically a linear operator, all of
+Since a discrete derivative operator is a linear operator, all of
 these SBP operators implement the basic interface of such linear operators
 (`AbstractMatrix` in Julia) such as multiplication by vectors and addition of
 operators. Finite difference and Fourier operators on periodic domains also
@@ -82,29 +89,48 @@ allow the construction of rational functions of operators and their efficient
 implementation using the fast Fourier transform [@frigo2005design].
 
 In addition to basic SBP derivative operators, SummationByPartsOperators.jl
-contains a number of artificial dissipation and filtering operators, such as
+contains a number of related operators, such as
 
 - SBP artificial dissipation operators
 - spectral viscosity operators for Fourier methods
 - modal filter operators for Fourier methods and Legendre pseudospectral methods
 
+Using Julia's rich type system, all of these operators are implemented as their
+own types. This enables several optimizations such as a memory requirement
+independent of the number of grid points. In contrast, implementations based
+on sparse/banded matrices have a memory requirement growing linearly with the
+number of grid points. In addition, the structure of the operators can be taken
+into account for operator-vector multiplications, usually resulting in speed-ups
+of an order of magnitude or more on consumer hardware. For example, the application
+of the sixth-order (in the interior) finite difference SBP operator on a grid
+with 1000 nodes takes roughly 330 ns on a consumer CPU from 2017 (Intel® Core™ i7-8700K)
+using version v0.5.5 of SummationByPartsOperators.jl. In contrast, the same
+operation takes roughly 3.9 microseconds using a sparse matrix format used in
+other implementations of this operator [@almquist2017optimized].
+
 Following good software development practices, SummationByPartsOperators.jl
 makes use of continuous integration and automated tests required before merging
-pull requests. Documentation is provided both in form of docstrings, a general
-introduction, and tutorials.
+pull requests. Documentation is provided in form of docstrings, a general
+introduction, and tutorials. In addition, SummationByPartsOperators.jl is a
+registered Julia package and can be installed using the built-in package manager,
+handling dependencies and version requirements automatically.
 
 
 # Related research and software
 
 There are of course many open-source software packages providing discretizations
 of differential equations. However, many of them focus on a single class of
-numerical methods, e.g.,
+numerical methods or a specific application, e.g.,
 
-- finite difference methods ([DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl), a part of DifferentialEquations.jl [@rackauckas2017differentialequations])
-- finite volume methods [@ramadhan2020oceananigans;@xiao2021kinetic]
-- spectral methods [@olver2014practical;@constantinou2021fourierflows]
-- finite element methods [@badia2020gridap]
-- discontinuous spectral element methods [@schlottkelakemper2021purely;@schlottkelakemper2020trixi]
+- finite difference methods ([DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl),
+  a part of DifferentialEquations.jl [@rackauckas2017differentialequations])
+- finite volume methods (Oceananigans.jl [@ramadhan2020oceananigans],
+  Kinetic.jl [@xiao2021kinetic])
+- spectral methods (ApproxFun.jl [@olver2014practical],
+  FourierFlows.jl [@constantinou2021fourierflows])
+- finite element methods (Gridap.jl [@badia2020gridap])
+- discontinuous spectral element methods
+  (Trixi.jl [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
 
 We are not aware of any open-source software library implementing all of the
 SBP classes using a unified interface or even several finite difference
@@ -113,6 +139,19 @@ optimized [@mattsson2014optimal;@mattsson2018boundary] and not available in
 other open source packages. Sometimes, restricted sets of coefficients are
 available online [@almquist2017optimized;@oreilly2019sbp], but there is no other
 extensive collection of these methods.
+
+Of course, there is a plethora of additional open source software implementing
+numerical methods for PDEs and each package has its own design criteria and goals.
+SummationByPartsOperators.jl provides a unified interface of different SBP
+operators. Thus, there is a partial overlap with some of the packages mentioned
+above such as finite difference operators on periodic domains (DiffEqOperators.jl,
+but with a different handling of bounded domains) or Fourier methods on periodic
+domains (ApproxFun.jl, but with a different interface and extensions). In addition,
+many packages focus on a specific application such as some specific fluid models
+(Oceananigans.jl, FourierFlows.jl) or hyperbolic PDEs (Trixi.jl). In contrast,
+SummationByPartsOperators.jl focuses on the numerical methods and provides them
+in a form usable for rather general PDEs. For example, there is ongoing work to
+use the basic operators provided by SummationByPartsOperators.jl in Trixi.jl.
 
 Some of the research projects that have made use of SummationByPartsOperators.jl
 (most of which have led to its further development) include numerical analysis

--- a/paper.md
+++ b/paper.md
@@ -127,10 +127,10 @@ numerical methods or a specific application, e.g.,
 - finite volume methods ([Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl) [@ramadhan2020oceananigans],
   [Kinetic.jl](https://github.com/vavrines/Kinetic.jl) [@xiao2021kinetic])
 - spectral methods ([ApproxFun.jl](https://github.com/JuliaApproximation/ApproxFun.jl) [@olver2014practical],
-  [FourierFlows.jl](https://doi.org/10.5281/zenodo.1161724) [@constantinou2021fourierflows])
+  [FourierFlows.jl](https://github.com/FourierFlows/FourierFlows.jl) [@constantinou2021fourierflows])
 - finite element methods ([Gridap.jl](https://github.com/gridap/Gridap.jl) [@badia2020gridap])
 - discontinuous spectral element methods
-  ([Trixi.jl](https://doi.org/10.5281/zenodo.3996439) [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
+  ([Trixi.jl](https://github.com/trixi-framework/Trixi.jl) [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
 
 We are not aware of any open-source software library implementing all of the
 SBP classes using a unified interface or even several finite difference

--- a/paper.md
+++ b/paper.md
@@ -111,28 +111,28 @@ SummationByPartsOperators.jl. In contrast, the same operation takes roughly
 this operator [@almquist2017optimized]. This benchmark is based on the following
 code, which also provides a very basic example of SummationByPartsOperators.jl.
 ```julia
-julia> # install the package if necessary
-       using Pkg; Pkg.add("SummationByPartsOperators")
+# install the package if necessary
+using Pkg; Pkg.add("SummationByPartsOperators")
 
-julia> using SummationByPartsOperators # load the package
+# load the package
+using SummationByPartsOperators
 
-julia> # create a finite difference SBP operator
-       D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(),
-          derivative_order=1, accuracy_order=6, xmin=0.0, xmax=1.0, N=10^3)
-SBP first-derivative operator of order 6 on a grid in [0.0, 1.0] using 1000 nodes
-and coefficients of Mattsson, Almquist, van der Weide (2018)
-  Boundary optimized diagonal-norm SBP operators ('Accurate').
-  Journal of Computational Physics 374, pp. 1261-1266.
+# create a finite difference SBP operator
+D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(),
+                        derivative_order=1, accuracy_order=6,
+                        xmin=0.0, xmax=1.0, N=10^3)
 
-julia> # evaluate the function `sinpi` on the discrete grid
-       x = grid(D); u = sinpi.(x);
+# evaluate the function `sinpi` on the discrete grid
+x = grid(D); u = sinpi.(x)
 
-julia> du = D * u; # use `D` to approximate the derivative of `u`
+# use `D` to approximate the derivative of `u`
+du = D * u
 
-julia> # compute the discrete L² error of the approximation
-       integrate(u -> u^2, du - pi * cospi.(x), D) |> sqrt
-4.238102975456189e-13
+# compute the discrete L² error of the approximation
+integrate(u -> u^2, du - pi * cospi.(x), D) |> sqrt
 ```
+The output of the last command will be a relatively small number on the order of
+`4.2-13`.
 
 Following good software development practices, SummationByPartsOperators.jl
 makes use of continuous integration and automated tests required before merging

--- a/paper.md
+++ b/paper.md
@@ -103,11 +103,29 @@ on sparse/banded matrices have a memory requirement growing linearly with the
 number of grid points. In addition, the structure of the operators can be taken
 into account for operator-vector multiplications, usually resulting in speed-ups
 of an order of magnitude or more on consumer hardware. For example, the application
-of the sixth-order (in the interior) finite difference SBP operator on a grid
-with 1000 nodes takes roughly 330 ns on a consumer CPU from 2017 (Intel® Core™ i7-8700K)
-using version v0.5.5 of SummationByPartsOperators.jl. In contrast, the same
-operation takes roughly 3.9 microseconds using a sparse matrix format used in
-other implementations of this operator [@almquist2017optimized].
+an optimized the sixth-order (in the interior) finite difference SBP operator
+[@almquist2017optimized] on a grid with 1000 nodes takes roughly 330 ns
+on a consumer CPU from 2017 (Intel® Core™ i7-8700K) using version v0.5.5 of
+SummationByPartsOperators.jl. In contrast, the same operation takes roughly
+3.9 microseconds using a sparse matrix format used in other implementations of
+this operator [@almquist2017optimized]. This benchmark is based on the following
+code, which also provides a very basic example of SummationByPartsOperators.jl.
+```julia
+julia> using Pkg; Pkg.add("SummationByPartsOperators") # if not installed previously
+
+julia> using SummationByPartsOperators # load the package
+
+julia> D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(), derivative_order=1,
+                               accuracy_order=6, xmin=0.0, xmax=1.0, N=10^3)
+
+julia> x = grid(D); u = sinpi.(x); # evaluate the function `sinpi` on the discrete grid
+
+julia> du = D * u; # evaluate the discrete derivative of `u` using the SBP operator `D`
+
+julia> integrate(u -> u^2,
+         du - π * cospi.(x), D) |> sqrt # compute the discrete L² error of the approximation
+4.238102975456189e-13
+```
 
 Following good software development practices, SummationByPartsOperators.jl
 makes use of continuous integration and automated tests required before merging

--- a/paper.md
+++ b/paper.md
@@ -127,10 +127,10 @@ numerical methods or a specific application, e.g.,
 - finite volume methods ([Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl) [@ramadhan2020oceananigans],
   [Kinetic.jl](https://github.com/vavrines/Kinetic.jl) [@xiao2021kinetic])
 - spectral methods ([ApproxFun.jl](https://github.com/JuliaApproximation/ApproxFun.jl) [@olver2014practical],
-  [FourierFlows.jl](https://github.com/FourierFlows/FourierFlows.jl) [@constantinou2021fourierflows])
+  [FourierFlows.jl](https://doi.org/10.5281/zenodo.1161724) [@constantinou2021fourierflows])
 - finite element methods ([Gridap.jl](https://github.com/gridap/Gridap.jl) [@badia2020gridap])
 - discontinuous spectral element methods
-  ([Trixi.jl](https://github.com/trixi-framework/Trixi.jl) [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
+  ([Trixi.jl](https://doi.org/10.5281/zenodo.3996439) [@schlottkelakemper2021purely;@schlottkelakemper2020trixi])
 
 We are not aware of any open-source software library implementing all of the
 SBP classes using a unified interface or even several finite difference


### PR DESCRIPTION
This PR addresses the following comments of #108:

- [x] Concerning related sopftware I have two remarks
  - It does not get clear to what extend there is an overlap of the current package to the mentioned ones. For example it sounds a little bit like the current package can be used to solve all problems from the mentioned packages? A little more detail on the relations would be neat
  - While for the first related software both the title/link to the software are mentioned as well as a reference, oáll others are just mentioned with a reference. Could these maybe be extended to also cover software package names and links to the repositories?
- [x] line 19: The word “resulting” seems to be mispaceed. Just the development of software will most probably not lead to disjoint communities. Maybe you meant that disjoint communities yuield different implementations and what is missing is a joint approach, also because the disjoint communities use different vocabulary?
- [x] line 32/33: You calim that the package is “reasonably fast”, but this is nowhere supported by a benchmark, comparison or reference. Where does this claim originate from? Sure there is a Benchmark section in the documentation, but I am missing a comparison to other approaches/packages for such a claim. This might also be, because I am – concerning these numerics – not an expert on performance. It would be nice to still justify this claim.
- [x] > line 35: The claim that the software was used in graduate courses is also without reference/example nor what the benefits of using it were.

  I described the benefits of using this package briefly. However, the course material was only available to students in internal IT frameworks of the universities. Thus, I don't see a reasonable way to provide references for this statement. Just writing the title of such a class as an example will not really provide more information to the readers, I guess. If you think otherwise, I will be happy to provide such an example.
- [x] line 55: the term “both” is followed by an enumeration of three terms (with the correct use of a comma before the “and”), so “both” is a wrong reference for this
- [x] line 43: The word “basically” can maybe be left out?
- [x] lines 49/50: the words “artificial dissipation” is used in line 49 and again directly in the first example line 50, so this is a repetition. Can this maybe be avoided?

@kellertuer: It would be great if you could review this PR.