### PR TITLE
fix "Edit on GitHub" links of license/contributing

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,16 @@ using SummationByPartsOperators
 DocMeta.setdocmeta!(SummationByPartsOperators,
   :DocTestSetup, :(using SummationByPartsOperators); recursive=true)
 
+# Copy some files from the top level directory to the docs and modify them
+# as necessary
 open(joinpath(@__DIR__, "src", "license.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/ranocha/SummationByPartsOperators.jl/blob/main/LICENSE.md"
+  ```
+  """)
+  # Write the modified contents
   println(io, "# License")
   println(io, "")
   for line in eachline(joinpath(dirname(@__DIR__), "LICENSE.md"))
@@ -16,6 +25,13 @@ open(joinpath(@__DIR__, "src", "license.md"), "w") do io
 end
 
 open(joinpath(@__DIR__, "src", "contributing.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/ranocha/SummationByPartsOperators.jl/blob/main/CONTRIBUTING.md"
+  ```
+  """)
+  # Write the modified contents
   println(io, "# Contributing")
   println(io, "")
   for line in eachline(joinpath(dirname(@__DIR__), "CONTRIBUTING.md"))


### PR DESCRIPTION
See https://github.com/JuliaDocs/Documenter.jl/issues/1650, https://github.com/JuliaDocs/Documenter.jl/issues/1620

Fixes an issue raised in #108. Closes https://github.com/JuliaDocs/Documenter.jl/issues/1650.

The docs of this PR are available at https://ranocha.de/SummationByPartsOperators.jl/previews/PR110 as long as it is open.