### PR TITLE
implement 5-arg `mul!` for discontinuously coupled operators

### DIFF
--- a/test/conservation_laws/burgers_test.jl
+++ b/test/conservation_laws/burgers_test.jl
@@ -1,6 +1,6 @@
 using Test, SummationByPartsOperators
 
-for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
+@testset "Burgers" for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
     xmin = T(-1)
     xmax = T(1)
     N = 2^6

--- a/test/conservation_laws/cubic_test.jl
+++ b/test/conservation_laws/cubic_test.jl
@@ -1,7 +1,7 @@
 using Test, SummationByPartsOperators
 using OrdinaryDiffEq, DiffEqCallbacks
 
-for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
+@testset "Cubic" for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
     xmin = T(-1)
     xmax = T(1)
     N = 2^6
@@ -18,7 +18,7 @@ for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
         semi(du, ode.u0, nothing, first(tspan))
 
         saving = SavingCallback(semi, saveat=range(tspan..., length=10))
-        sol = solve(ode, SSPRK104(), dt=1/5N, save_everystep=false, callback=saving)
+        sol = solve(ode, SSPRK104(), dt=T(1/5N), save_everystep=false, callback=saving)
     end
 
     # Periodic FD
@@ -32,7 +32,7 @@ for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
         semi(du, ode.u0, nothing, first(tspan))
 
         saving = SavingCallback(semi, saveat=range(tspan..., length=10))
-        sol = solve(ode, SSPRK104(), dt=1/5N, save_everystep=false, callback=saving)
+        sol = solve(ode, SSPRK104(), dt=T(1/5N), save_everystep=false, callback=saving)
     end
 
     # Legendre
@@ -45,7 +45,7 @@ for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
         semi(du, ode.u0, nothing, first(tspan))
 
         saving = SavingCallback(semi, saveat=range(tspan..., length=10))
-        sol = solve(ode, SSPRK104(), dt=1/(1+N^20), save_everystep=false, callback=saving)
+        sol = solve(ode, SSPRK104(), dt=T(1/(1+N^20)), save_everystep=false, callback=saving)
     end
 
     # SBP FD
@@ -59,6 +59,6 @@ for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
         semi(du, ode.u0, nothing, first(tspan))
 
         saving = SavingCallback(semi, saveat=range(tspan..., length=10))
-        sol = solve(ode, SSPRK104(), dt=1/5N, save_everystep=false, callback=saving)
+        sol = solve(ode, SSPRK104(), dt=T(1/5N), save_everystep=false, callback=saving)
     end
 end

--- a/test/conservation_laws/quartic_nonconvex_test.jl
+++ b/test/conservation_laws/quartic_nonconvex_test.jl
@@ -1,7 +1,7 @@
 using Test, SummationByPartsOperators
 using OrdinaryDiffEq, DiffEqCallbacks
 
-for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
+@testset "Quartic" for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
     xmin = T(-1)
     xmax = T(1)
     N = 2^6

--- a/test/conservation_laws/variable_linear_advection_test.jl
+++ b/test/conservation_laws/variable_linear_advection_test.jl
@@ -1,6 +1,6 @@
 using Test, SummationByPartsOperators
 
-for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
+@testset "Var. lin. adv." for T in (Float32, Float64), split_form in (Val{true}(), Val{false}())
     xmin = T(-1)
     xmax = T(1)
     N = 2^6

--- a/test/coupling_test.jl
+++ b/test/coupling_test.jl
@@ -46,8 +46,9 @@ using SummationByPartsOperators
           if cD == cD_continuous
             @test_throws ArgumentError mul!(du, cD, u, 2.0, 3.0)
           else
+            du .= u
             mul!(du, cD, u, 2.0, 3.0)
-            @test du ≈ 2 * cD * u + 3 * u
+            @test du ≈ 2 * (cD * u) + 3 * u
           end
         end
         M = mass_matrix(cD_central)
@@ -179,8 +180,9 @@ end
             if cD == cD_continuous
               @test_throws ArgumentError mul!(du, cD, u, 2.0, 3.0)
             else
+              du .= u
               mul!(du, cD, u, 2.0, 3.0)
-              @test du ≈ 2 * cD * u + 3 * u
+              @test du ≈ 2 * (cD * u) + 3 * u
             end
           end
           M = mass_matrix(cD_central)

--- a/test/coupling_test.jl
+++ b/test/coupling_test.jl
@@ -41,6 +41,14 @@ using SummationByPartsOperators
           @test cD * u ≈ sparse(cD) * u atol=eps(float(T)) rtol=sqrt(eps(float(T)))
           @test SummationByPartsOperators.xmin(cD) ≈ xmin
           @test SummationByPartsOperators.xmax(cD) ≈ xmax
+
+          du = copy(u)
+          if cD == cD_continuous
+            @test_throws ArgumentError mul!(du, cD, u, 2.0, 3.0)
+          else
+            mul!(du, cD, u, 2.0, 3.0)
+            @test du ≈ 2 * cD * u + 3 * u
+          end
         end
         M = mass_matrix(cD_central)
         @test M ≈ mass_matrix(cD_plus)
@@ -166,6 +174,14 @@ end
             @test cD * u ≈ sparse(cD) * u atol=eps(float(T)) rtol=sqrt(eps(float(T)))
             @test SummationByPartsOperators.xmin(cD) ≈ xmin
             @test SummationByPartsOperators.xmax(cD) ≈ xmax
+
+            du = copy(u)
+            if cD == cD_continuous
+              @test_throws ArgumentError mul!(du, cD, u, 2.0, 3.0)
+            else
+              mul!(du, cD, u, 2.0, 3.0)
+              @test du ≈ 2 * cD * u + 3 * u
+            end
           end
           M = mass_matrix(cD_central)
           @test M ≈ mass_matrix(cD_plus)


### PR DESCRIPTION
Related to #145, but considers only the simple case of discontinuous coupling.