### PR TITLE
fix `summary` of `UpwindOperators`

### DIFF
--- a/src/upwind_operators.jl
+++ b/src/upwind_operators.jl
@@ -61,7 +61,7 @@ end
 
 function Base.summary(io::IO, D::UpwindOperators)
   acc = accuracy_order(D.minus), accuracy_order(D.central), accuracy_order(D.minus)
-  if allequal(acc)
+  if all(==(accuracy_order(D.minus)), acc)
     acc_string = string(first(acc))
   else
     acc_string = string(acc)


### PR DESCRIPTION
`allequal` is defined only in Julia 1.8 and newer