### PR TITLE
Bump crate-ci/typos from 1.14.5 to 1.14.6

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v3
       - name: Check spelling
-        uses: crate-ci/typos@v1.14.5
+        uses: crate-ci/typos@v1.14.6


### PR DESCRIPTION
Manual version of https://github.com/ranocha/SummationByPartsOperators.jl/pull/179 to see whether the documentation failure happens here, too

Closes #179