### PR TITLE
check CI on Julia v1.10 pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
             os: ubuntu-latest
             arch: x64
             sbp_test: part2
+          - version: '~1.10.0-0'
+            os: ubuntu-latest
+            arch: x64
+            sbp_test: part1
+          - version: '~1.10.0-0'
+            os: ubuntu-latest
+            arch: x64
+            sbp_test: part2
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Motivated by the reports of local test failures by @jlchan in #202 - let's see what we get in CI with the current pre-release of Julia v1.10