### PR TITLE
fix addition of DerivativeCoefficientRows with different Start values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummationByPartsOperators"
 uuid = "9f78cca6-572e-554e-b819-917d2f1cf240"
 author = ["Hendrik Ranocha"]
-version = "0.5.59"
+version = "0.5.60"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/SBP_operators.jl
+++ b/src/SBP_operators.jl
@@ -141,11 +141,11 @@ function Base.:+(coef_row1::DerivativeCoefficientRow{T,Start1,Length1}, coef_row
     Length = End - Start
     row = SVector{Length,T}(ntuple(i -> zero(T), Length))
     for i in 1:Length1
-        j = i-Start1+Start
+        j = i+Start1-Start
         row = Base.setindex(row, row[j] + coef_row1.coef[i], j)
     end
     for i in 1:Length2
-        j = i-Start2+Start
+        j = i+Start2-Start
         row = Base.setindex(row, row[j] + coef_row2.coef[i], j)
     end
     DerivativeCoefficientRow{T,Start,Length}(row)

--- a/test/linear_combinations_of_operators_test.jl
+++ b/test/linear_combinations_of_operators_test.jl
@@ -112,24 +112,3 @@ for T in (Float32, Float64)
         @test combi * u ≈ D₁ * u + D₂ * u
     end
 end
-
-@testset "DerivativeCoefficientRow" begin
-    row1 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1,2,3])
-    row2 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([2,4,6])
-    row3 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,2,3}([2,4,6])
-
-    @test -row1 ==
-        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([-1,-2,-3])
-
-    @test row1 + row2 ==
-        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([3,6,9])
-
-    @test row1 + row3 ==
-        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1,4,7,6])
-
-    @test row1 / 2 ==
-        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1//2, 2//2, 3//2])
-
-    @test (row1 + -row3) / 2 ==
-        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1//2, 0, -1//2, -3])
-end

--- a/test/linear_combinations_of_operators_test.jl
+++ b/test/linear_combinations_of_operators_test.jl
@@ -112,3 +112,24 @@ for T in (Float32, Float64)
         @test combi * u ≈ D₁ * u + D₂ * u
     end
 end
+
+@testset "DerivativeCoefficientRow" begin
+    row1 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1,2,3])
+    row2 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([2,4,6])
+    row3 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,2,3}([2,4,6])
+
+    @test -row1 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([-1,-2,-3])
+
+    @test row1 + row2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([3,6,9])
+
+    @test row1 + row3 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1,4,7,6])
+
+    @test row1 / 2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1//2, 2//2, 3//2])
+
+    @test (row1 + -row3) / 2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1//2, 0, -1//2, -3])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ const SBP_TEST = get(ENV, "SBP_TEST", "all")
 
 @time @testset "SummationByPartsOperators.jl tests" begin
     @time if SBP_TEST == "all" || SBP_TEST == "part1"
+        @time @testset "Unit Tests" begin include("unit_tests.jl") end
         @time @testset "Periodic Operators" begin include("periodic_operators_test.jl") end
         @time @testset "Non-Periodic Operators" begin include("SBP_operators_test.jl") end
         @time @testset "Dissipation Operators" begin include("dissipation_operators_test.jl") end

--- a/test/unit_tests.jl
+++ b/test/unit_tests.jl
@@ -1,0 +1,23 @@
+using Test
+using SummationByPartsOperators
+
+@testset "DerivativeCoefficientRow" begin
+    row1 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1,2,3])
+    row2 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([2,4,6])
+    row3 = SummationByPartsOperators.DerivativeCoefficientRow{Rational,2,3}([2,4,6])
+
+    @test -row1 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([-1,-2,-3])
+
+    @test row1 + row2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([3,6,9])
+
+    @test row1 + row3 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1,4,7,6])
+
+    @test row1 / 2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,3}([1//2, 2//2, 3//2])
+
+    @test (row1 + -row3) / 2 ==
+        SummationByPartsOperators.DerivativeCoefficientRow{Rational,1,4}([1//2, 0, -1//2, -3])
+end


### PR DESCRIPTION
Adding together two `DerivativeCoefficientRow` variables with different `Start` values throws a bounds error.
For example,
```julia
import SummationByPartsOperators
row1 = SummationByPartsOperators.DerivativeCoefficientRow{Int, 0, 3}([1,2,3])
row2 = SummationByPartsOperators.DerivativeCoefficientRow{Int, 1, 3}([1,2,3])
row1 + row2
```
results in
```julia
ERROR: BoundsError: attempt to access NTuple{4, Int64} at index [0]
Stacktrace:
 [1] getindex
   @ ./tuple.jl:31 [inlined]
 [2] getindex
   @ ~/.julia/packages/StaticArrays/EHHaF/src/SArray.jl:62 [inlined]
 [3] +(coef_row1::SummationByPartsOperators.DerivativeCoefficientRow{Int64, 0, 3}, coef_row2::SummationByPartsOperators.DerivativeCoefficientRow{Int64, 1, 3})
   @ SummationByPartsOperators ~/.julia/packages/SummationByPartsOperators/DBpfT/src/SBP_operators.jl:149
 [4] top-level scope
   @ REPL[4]:1
```
After applying the fix, it returns
```julia
SummationByPartsOperators.DerivativeCoefficientRow{Int64, 0, 4}([1, 3, 5, 3])
```