### PR TITLE
Add more kwargs (`opt_alg` and `verbose`) to FSBP operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummationByPartsOperators"
 uuid = "9f78cca6-572e-554e-b819-917d2f1cf240"
 author = ["Hendrik Ranocha"]
-version = "0.5.63"
+version = "0.5.64"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/function_space_operators.jl
+++ b/src/function_space_operators.jl
@@ -37,7 +37,8 @@ end
 """
     function_space_operator(basis_functions, nodes, source;
                             derivative_order = 1, accuracy_order = 0,
-                            options = Optim.Options(g_tol = 1e-14, iterations = 10000))
+                            opt_alg = Optim.LBFGS(), options = Optim.Options(g_tol = 1e-14, iterations = 10000),
+                            verbose = false)
 
 Construct an operator that represents a first-derivative operator in a function space spanned by
 the `basis_functions`, which is an iterable of functions. The operator is constructed on the
@@ -45,8 +46,9 @@ interval `[x_min, x_max]` with the nodes `nodes`, where `x_min` is taken as the 
 `nodes` and `x_max` the maximal value. Note that the `nodes` will be sorted internally. The
 `accuracy_order` is the order of the accuracy of the operator, which can optionally be passed,
 but does not have any effect on the operator. The operator is constructed solving an optimization
-problem with Optim.jl. You can specify the options for the optimization problem with the `options`
-argument, see also the [documentation of Optim.jl](https://julianlsolvers.github.io/Optim.jl/stable/user/config/).
+problem with Optim.jl. You can specify the optimization algorithm and options for the optimization problem
+with the keyword arguments `opt_alg` and `options` respectively, see also the
+[documentation of Optim.jl](https://julianlsolvers.github.io/Optim.jl/stable/user/config/)
 
 The operator that is returned follows the general interface. Currently, it is wrapped in a
 [`MatrixDerivativeOperator`](@ref), but this might change in the future.


### PR DESCRIPTION
Sometimes it can be better to use another optimization algorithm from Optim.jl than LBFGS (I have seen that BFGS sometimes outperforms LBFGS significantly). In order to easily switch between solvers, I added a kwarg to set the solver. In addition, I often want to inspect the result of the optimization procedure. To do this more easily I also added another kwarg `verbose` to display the result.