### PR TITLE
Fix `BoundaryAdaptedGrid` for only one central point

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummationByPartsOperators"
 uuid = "9f78cca6-572e-554e-b819-917d2f1cf240"
 author = ["Hendrik Ranocha"]
-version = "0.5.65"
+version = "0.5.66"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
+++ b/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
@@ -27,6 +27,7 @@ struct BoundaryAdaptedGrid{T,M,Grid} <: AbstractArray{T,1}
   xmax::T
   xstart::SVector{M,T}
   uniform_grid::Grid
+  Δx::T
 end
 
 function BoundaryAdaptedGrid(xmin::T, xmax::T, _xstart::SVector{M,T}, N::Int) where {M,T}
@@ -40,7 +41,7 @@ function BoundaryAdaptedGrid(xmin::T, xmax::T, _xstart::SVector{M,T}, N::Int) wh
   else
     uniform_grid = range(xmin + xstart[end] + Δx, xmax - xstart[end] - Δx, length=N-2M)
   end
-  BoundaryAdaptedGrid{T,M,typeof(uniform_grid)}(xmin, xmax, xstart, uniform_grid)
+  BoundaryAdaptedGrid{T,M,typeof(uniform_grid)}(xmin, xmax, xstart, uniform_grid, Δx)
 end
 
 function BoundaryAdaptedGrid(xmin, xmax, xstart, N)
@@ -71,7 +72,7 @@ function Base.getindex(grid::BoundaryAdaptedGrid, i::Int)
 end
 
 Base.size(grid::BoundaryAdaptedGrid) = (length(grid),)
-Base.step(grid::BoundaryAdaptedGrid) = (grid.xmax - grid.xmin - 2*grid.xstart[end]) / (length(grid) + 1 - 2*length(grid.xstart))
+Base.step(grid::BoundaryAdaptedGrid) = grid.Δx
 
 
 function construct_grid(::MattssonAlmquistVanDerWeide2018Minimal, accuracy_order, xmin, xmax, N)

--- a/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
+++ b/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
@@ -35,7 +35,11 @@ function BoundaryAdaptedGrid(xmin::T, xmax::T, _xstart::SVector{M,T}, N::Int) wh
 
   Δx = (xmax - xmin) / (2*_xstart[end] + N + 1 - 2M)
   xstart = Δx .* _xstart
-  uniform_grid = range(xmin + xstart[end] + Δx, xmax - xstart[end] - Δx, length=N-2M)
+  if N - 2M == 1 # This is to avoid an error if starting and end points are not the same due to rounding errors
+    uniform_grid = range(xmax - xstart[end] - Δx, xmax - xstart[end] - Δx, length=1)
+  else
+    uniform_grid = range(xmin + xstart[end] + Δx, xmax - xstart[end] - Δx, length=N-2M)
+  end
   BoundaryAdaptedGrid{T,M,typeof(uniform_grid)}(xmin, xmax, xstart, uniform_grid)
 end
 
@@ -67,7 +71,7 @@ function Base.getindex(grid::BoundaryAdaptedGrid, i::Int)
 end
 
 Base.size(grid::BoundaryAdaptedGrid) = (length(grid),)
-Base.step(grid::BoundaryAdaptedGrid) = step(grid.uniform_grid)
+Base.step(grid::BoundaryAdaptedGrid) = grid.uniform_grid[1] - grid.xstart[end]
 
 
 function construct_grid(::MattssonAlmquistVanDerWeide2018Minimal, accuracy_order, xmin, xmax, N)

--- a/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
+++ b/src/SBP_coefficients/MattssonAlmquistVanDerWeide2018Minimal.jl
@@ -71,7 +71,7 @@ function Base.getindex(grid::BoundaryAdaptedGrid, i::Int)
 end
 
 Base.size(grid::BoundaryAdaptedGrid) = (length(grid),)
-Base.step(grid::BoundaryAdaptedGrid) = grid.uniform_grid[1] - grid.xstart[end]
+Base.step(grid::BoundaryAdaptedGrid) = (grid.xmax - grid.xmin - 2*grid.xstart[end]) / (length(grid) + 1 - 2*length(grid.xstart))
 
 
 function construct_grid(::MattssonAlmquistVanDerWeide2018Minimal, accuracy_order, xmin, xmax, N)

--- a/test/SBP_operators_test.jl
+++ b/test/SBP_operators_test.jl
@@ -1036,4 +1036,10 @@ end
                                          xmin = -1.0, xmax = 1.0,
                                          N = 20)
     end
+
+# https://github.com/ranocha/SummationByPartsOperators.jl/pull/281
+@testset "PR #281" begin
+    @test_nowarn D = derivative_operator(MattssonAlmquistVanDerWeide2018Minimal(), 1, 4, 0.0, 1.0, 9)
+    @test all(isfinite.(Matrix(D)))
+end
 end

--- a/test/SBP_operators_test.jl
+++ b/test/SBP_operators_test.jl
@@ -1039,7 +1039,7 @@ end
 
 # https://github.com/ranocha/SummationByPartsOperators.jl/pull/281
 @testset "PR #281" begin
-    @test_nowarn D = derivative_operator(MattssonAlmquistVanDerWeide2018Minimal(), 1, 4, 0.0, 1.0, 9)
+    D = @test_nowarn derivative_operator(MattssonAlmquistVanDerWeide2018Minimal(), 1, 4, 0.0, 1.0, 9)
     @test all(isfinite.(Matrix(D)))
 end
 end


### PR DESCRIPTION
This fixes two independent, but related issues regarding the `BoundaryAdaptedGrid`:
1. Previously the following failed:
```julia
D = derivative_operator(MattssonAlmquistVanDerWeide2018Minimal(), 1, 4, 0.0, 1.0, 9)
```
due to `ERROR: ArgumentError: range(0.4999999999999999, stop=0.5, length=1): endpoints differ`. This is because there is only one inner point and due to rounding errors the left and right ends are not the same. I simply added an if-statement for this. Let me know if you have a better idea to handle this @ranocha.

2. With this fix, the above code (or, e.g., also `D = derivative_operator(MattssonAlmquistVanDerWeide2018Accurate(), 1, 4, 0.0, 1.0, 11)`  already without the fix above) gives a result, but `step(grid)` gives zero, again, because there is only one point in the `uniform_grid`. This results in an operator with mass_matrix equal to zero and `Inf`s and `NaN`s for the entries of `Matrix(D)`. This modifies the `step` function for the `BoundaryAdaptedGrid` to return the actual step also for this edge case.