### PR TITLE
Use default `arch` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: ${{ matrix.sbp_test }} - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: ${{ matrix.sbp_test }} - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -57,26 +57,21 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
         sbp_test:
           - part1
           - part2
         include:
           - version: '1.8'
             os: ubuntu-latest
-            arch: x64
             sbp_test: part1
           - version: '1.8'
             os: ubuntu-latest
-            arch: x64
             sbp_test: part2
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -100,7 +95,7 @@ jobs:
       # - uses: coverallsapp/github-action@master
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     flag-name: run-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ github.run_id }}
+      #     flag-name: run-${{ join(matrix.*, '-') }}
       #     parallel: true
       #     path-to-lcov: ./lcov.info
       # Instead, we use a more tedious approach:
@@ -109,11 +104,11 @@ jobs:
       # - Upload only the merged coverage report to Coveralls
       - shell: bash
         run: |
-          cp ./lcov.info ./lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
+          cp ./lcov.info ./lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}.info
       - uses: actions/upload-artifact@v4
         with:
-          name: lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
-          path: ./lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
+          name: lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}
+          path: ./lcov-${{ matrix.sbp_test }}-${{ matrix.os }}-${{ matrix.version }}.info
 
   finish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,10 @@ jobs:
             sbp_test: part2
           - version: '1.6'
             os: macos-13 # Intel
-            sbp-test: part1
+            sbp_test: part1
           - version: '1.6'
             os: macos-13 # Intel
-            sbp-test: part2
+            sbp_test: part2
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
           PYTHON: ""
           SBP_TEST: ${{ matrix.sbp_test }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
-          file: ./lcov.info
+          files: ./lcov.info
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,16 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-latest
           - windows-latest
         sbp_test:
           - part1
           - part2
+        # macos-14 doesn't support Julia v1.6,
+        # cf. https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019
+        exclude:
+          - os: macos-latest
+            version: '1.6'
         include:
           - version: '1.8'
             os: ubuntu-latest
@@ -67,6 +72,12 @@ jobs:
           - version: '1.8'
             os: ubuntu-latest
             sbp_test: part2
+          - version: '1.6'
+            os: macos-13 # Intel
+            sbp-test: part1
+          - version: '1.6'
+            os: macos-13 # Intel
+            sbp-test: part2
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
There are warnings (e.g., https://github.com/ranocha/SummationByPartsOperators.jl/actions/runs/12125109358?pr=307) in the CI runs because we request x64 on a macOS runner with arm64. I propose to simply use the default architecture, i.e. to remove the `arch` argument.