### PR TITLE
require new version of FFTW

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummationByPartsOperators"
 uuid = "9f78cca6-572e-554e-b819-917d2f1cf240"
 author = ["Hendrik Ranocha"]
-version = "0.5.73"
+version = "0.5.74"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -42,7 +42,7 @@ ArgCheck = "1, 2.0"
 AutoHashEquals = "0.2, 1, 2"
 BandedMatrices = "0.17, 1"
 DiffEqCallbacks = "2, 3, 4"
-FFTW = "1"
+FFTW = "1.8"
 ForwardDiff = "0.10"
 InteractiveUtils = "1"
 LinearAlgebra = "1"


### PR DESCRIPTION
Some Trixi.jl tests fail since an old version of FFTW.jl is used, e.g., version 1.1.1 (from 2019?) instead of a recent version like 1.8, see

https://github.com/trixi-framework/Trixi.jl/actions/runs/12877053965/job/35900961134?pr=2243#step:7:151

and 

https://github.com/trixi-framework/Trixi.jl/pull/2243

This old version of FFTW.jl uses BinaryProvider.jl which is archived and not maintained anymore. Thus, I will update SUmmationByPartsOperators.jl to require newer versions of FFTW.jl that do not use BinaryProvider.jl anymore.