### PR TITLE
Remove deprecated DiffEqOperators.jl from docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SummationByPartsOperators"
 uuid = "9f78cca6-572e-554e-b819-917d2f1cf240"
 author = ["Hendrik Ranocha"]
-version = "0.5.76"
+version = "0.5.77"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-DiffEqOperators = "9fdde737-9c7f-55bf-ade8-46b3f136cc48"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
@@ -14,7 +13,6 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 [compat]
 BandedMatrices = "0.15, 0.16, 0.17, 1"
 BenchmarkTools = "0.5, 0.7, 1.0 - 1.2.0, 1.2.2"
-DiffEqOperators = "4.26"
 Documenter = "1"
 ForwardDiff = "0.10"
 LaTeXStrings = "1.2"

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -13,7 +13,7 @@ Let's set up some benchmark code.
 ```@example first-derivative-periodic
 using BenchmarkTools
 using LinearAlgebra, SparseArrays
-using SummationByPartsOperators, DiffEqOperators
+using SummationByPartsOperators
 
 BLAS.set_num_threads(1) # make sure that BLAS is serial to be fair
 
@@ -23,13 +23,10 @@ xmin, xmax = T(0), T(1)
 D_SBP = periodic_derivative_operator(derivative_order=1, accuracy_order=2,
                                      xmin=xmin, xmax=xmax, N=100)
 x = grid(D_SBP)
-D_DEO = CenteredDifference(derivative_order(D_SBP), accuracy_order(D_SBP),
-                           step(x), length(x)) * PeriodicBC(eltype(D_SBP))
 
 D_sparse = sparse(D_SBP)
 
 u = randn(eltype(D_SBP), length(x)); du = similar(u);
-@show D_SBP * u ≈ D_DEO * u ≈ D_sparse * u
 
 function doit(D, text, du, u)
   println(text)
@@ -51,19 +48,13 @@ of magnitude slower than the optimized implementation from SummationByPartsOpera
 doit(D_sparse, "D_sparse:", du, u)
 ```
 
-Finally, we benchmark the implementation of the same derivative operator in
-DiffEqOperators.jl.
-```@example first-derivative-periodic
-doit(D_DEO, "D_DEO:", du, u)
-```
-
 These results were obtained using the following versions.
 ```@example first-derivative-periodic
 using InteractiveUtils
 versioninfo()
 
 using Pkg
-Pkg.status(["SummationByPartsOperators", "DiffEqOperators"],
+Pkg.status(["SummationByPartsOperators"],
            mode=PKGMODE_MANIFEST)
 nothing # hide
 ```

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -27,6 +27,7 @@ x = grid(D_SBP)
 D_sparse = sparse(D_SBP)
 
 u = randn(eltype(D_SBP), length(x)); du = similar(u);
+@show D_SBP * u ≈ D_sparse * u
 
 function doit(D, text, du, u)
   println(text)


### PR DESCRIPTION
Closes #326.
With this change, we can get the newest versions of the dependencies under Julia v1.11, but some doctests related to printing of `Rational`s fail (caused by https://github.com/JuliaLang/julia/pull/45396, which came in Julia v1.10). Do you prefer that the docs can be build with Julia pre v1.10 or with v1.10 and above, @ranocha? If the latter, I can update the doctests accordingly and let the docs build in CI with Julia v1.10 (possibly in another PR).