### PR TITLE
Improve multidimensional matrix operators

### DIFF
--- a/src/SummationByPartsOperators.jl
+++ b/src/SummationByPartsOperators.jl
@@ -152,7 +152,8 @@ export FilterCallback, ConstantFilter, ExponentialFilter
 export SafeMode, FastMode, ThreadedMode
 export derivative_order, accuracy_order, source_of_coefficients, grid, semidiscretize
 export mass_matrix, mass_matrix_boundary
-export integrate, integrate_boundary, restrict_boundary,
+export integrate, integrate_boundary,
+       restrict_interior, restrict_boundary,
        left_boundary_weight, right_boundary_weight,
        scale_by_mass_matrix!, scale_by_inverse_mass_matrix!,
        derivative_left, derivative_right,
@@ -165,6 +166,7 @@ export periodic_central_derivative_operator, periodic_derivative_operator,
        fourier_derivative_operator,
        legendre_derivative_operator, legendre_second_derivative_operator,
        upwind_operators, function_space_operator, tensor_product_operator_2D
+export normals, boundary_indices
 export UniformMesh1D, UniformPeriodicMesh1D
 export couple_continuously, couple_discontinuously
 export mul!

--- a/src/general_operators.jl
+++ b/src/general_operators.jl
@@ -309,7 +309,7 @@ restrict_boundary(u, D::AbstractPeriodicDerivativeOperator) = eltype(u)[]
 
 Restrict the coefficients `u` to the interior nodes of the derivative operator `D`.
 """
-restrict_interior(u, D::AbstractNonperiodicDerivativeOperator) = u[2:end-1]
+restrict_interior(u, D::AbstractNonperiodicDerivativeOperator) = u[2:(end - 1)]
 
 restrict_interior(u, D::AbstractPeriodicDerivativeOperator) = u
 

--- a/src/general_operators.jl
+++ b/src/general_operators.jl
@@ -305,6 +305,15 @@ restrict_boundary(u, D::AbstractNonperiodicDerivativeOperator) = u[[begin, end]]
 restrict_boundary(u, D::AbstractPeriodicDerivativeOperator) = eltype(u)[]
 
 """
+    restrict_interior(u, D::AbstractDerivativeOperator)
+
+Restrict the coefficients `u` to the interior nodes of the derivative operator `D`.
+"""
+restrict_interior(u, D::AbstractNonperiodicDerivativeOperator) = u[2:end-1]
+
+restrict_interior(u, D::AbstractPeriodicDerivativeOperator) = u
+
+"""
     mass_matrix_boundary(D::AbstractDerivativeOperator)
 
 Construct the mass matrix at the boundary of a derivative operator `D`. For classical 1D

--- a/src/general_operators.jl
+++ b/src/general_operators.jl
@@ -309,7 +309,7 @@ restrict_boundary(u, D::AbstractPeriodicDerivativeOperator) = eltype(u)[]
 
 Restrict the coefficients `u` to the interior nodes of the derivative operator `D`.
 """
-restrict_interior(u, D::AbstractNonperiodicDerivativeOperator) = u[2:(end - 1)]
+restrict_interior(u, D::AbstractNonperiodicDerivativeOperator) = u[(begin + 1):(end - 1)]
 
 restrict_interior(u, D::AbstractPeriodicDerivativeOperator) = u
 

--- a/src/multidimensional_matrix_operators.jl
+++ b/src/multidimensional_matrix_operators.jl
@@ -74,8 +74,26 @@ Base.ndims(::AbstractMultidimensionalMatrixDerivativeOperator{Dim}) where {Dim} 
 Base.getindex(D::AbstractMultidimensionalMatrixDerivativeOperator, i::Int) = D.Ds[i]
 Base.eltype(::AbstractMultidimensionalMatrixDerivativeOperator{Dim, T}) where {Dim, T} = T
 
+"""
+    normals(D::MultidimensionalMatrixDerivativeOperator)
+
+Return the normal vectors of the boundary nodes of a [`MultidimensionalMatrixDerivativeOperator`](@ref) `D`.
+"""
+normals(D::AbstractMultidimensionalMatrixDerivativeOperator) = D.normals
+
+"""
+    boundary_indices(D::MultidimensionalMatrixDerivativeOperator)
+
+Return the indices of the boundary nodes of a [`MultidimensionalMatrixDerivativeOperator`](@ref) `D`.
+"""
+boundary_indices(D::AbstractMultidimensionalMatrixDerivativeOperator) = D.boundary_indices
+
 function restrict_boundary(u, D::AbstractMultidimensionalMatrixDerivativeOperator)
     u[D.boundary_indices]
+end
+
+function restrict_interior(u, D::AbstractMultidimensionalMatrixDerivativeOperator)
+    u[setdiff(1:length(u), D.boundary_indices)]
 end
 
 """

--- a/src/multidimensional_matrix_operators.jl
+++ b/src/multidimensional_matrix_operators.jl
@@ -93,7 +93,7 @@ function restrict_boundary(u, D::AbstractMultidimensionalMatrixDerivativeOperato
 end
 
 function restrict_interior(u, D::AbstractMultidimensionalMatrixDerivativeOperator)
-    u[setdiff(1:length(u), D.boundary_indices)]
+    u[setdiff(eachindex(u), D.boundary_indices)]
 end
 
 """

--- a/src/tensor_product_operators.jl
+++ b/src/tensor_product_operators.jl
@@ -171,8 +171,3 @@ function tensor_product_operator_2D(D_x, D_y = D_x)
                                                        acc_order, source)
     return TensorProductOperator(D_multi, N_x, N_y)
 end
-
-function Base.kron(D_x::AbstractNonperiodicDerivativeOperator,
-                   D_y::AbstractNonperiodicDerivativeOperator)
-    tensor_product_operator_2D(D_x, D_y)
-end

--- a/src/tensor_product_operators.jl
+++ b/src/tensor_product_operators.jl
@@ -171,3 +171,8 @@ function tensor_product_operator_2D(D_x, D_y = D_x)
                                                        acc_order, source)
     return TensorProductOperator(D_multi, N_x, N_y)
 end
+
+function Base.kron(D_x::AbstractNonperiodicDerivativeOperator,
+                   D_y::AbstractNonperiodicDerivativeOperator)
+    tensor_product_operator_2D(D_x, D_y)
+end

--- a/test/SBP_operators_test.jl
+++ b/test/SBP_operators_test.jl
@@ -45,6 +45,9 @@ for source in D_test_list, T in (Float32, Float64)
         # SBP property
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 1000 * eps(T), eachindex(res))
@@ -112,6 +115,9 @@ for source in D_test_list, T in (Float32, Float64)
         # SBP property
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 1000 * eps(T), eachindex(res))
@@ -189,6 +195,9 @@ for source in D_test_list, T in (Float32, Float64)
         # SBP property
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 1000 * eps(T), eachindex(res))
@@ -276,6 +285,9 @@ for source in D_test_list, T in (Float32, Float64)
         # SBP property
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 16000 * eps(T), eachindex(res))
@@ -438,6 +450,9 @@ for source in D_test_list, T in (Float32, Float64)
         dL = derivative_left(D, Val{1}())
         dR = derivative_right(D, Val{1}())
         @test M * Matrix(D) - Matrix(D)' * M ≈ eR * dR' - eL * dL' - dR * eR' + dL * eL'
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 2000 * eps(T), eachindex(res))
@@ -509,6 +524,9 @@ for source in D_test_list, T in (Float32, Float64)
         dL = derivative_left(D, Val{1}())
         dR = derivative_right(D, Val{1}())
         @test M * Matrix(D) - Matrix(D)' * M ≈ eR * dR' - eL * dL' - dR * eR' + dL * eL'
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 10000 * eps(T), eachindex(res))
@@ -587,6 +605,9 @@ for source in D_test_list, T in (Float32, Float64)
         dL = derivative_left(D, Val{1}())
         dR = derivative_right(D, Val{1}())
         @test M * Matrix(D) - Matrix(D)' * M ≈ eR * dR' - eL * dL' - dR * eR' + dL * eL'
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 10000 * eps(T), eachindex(res))
@@ -669,6 +690,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < eps(T), eachindex(res))
@@ -730,6 +754,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 100_000 * eps(T), eachindex(res))
@@ -800,6 +827,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 1_000_000 * eps(T), eachindex(res))
@@ -884,6 +914,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 10 * eps(T) / D.Δx^4, eachindex(res))
@@ -953,6 +986,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 50_000_000 * eps(T), eachindex(res))
@@ -1033,6 +1069,9 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+
+        @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
+        @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
         # interior and boundary
         mul!(res, D, x0)
         @test all(i -> abs(res[i]) < 50_000_000 * eps(T), eachindex(res))

--- a/test/multidimensional_matrix_operators_test.jl
+++ b/test/multidimensional_matrix_operators_test.jl
@@ -105,6 +105,7 @@ end
         D_2 = derivative_operator(MattssonAlmquistCarpenter2014Extended(), 1, acc_order,
                                   T(ymin_construction), T(ymax_construction), N_y)
         D_t = tensor_product_operator_2D(D_1, D_2)
+        @test kron(D_1, D_2) == D_t
 
         for compact in (true, false)
             show(IOContext(devnull, :compact => compact), D_t)
@@ -121,8 +122,21 @@ end
         end
         @test eltype(D_t) == eltype(D_1) == eltype(D_2) == T
         @test real(D_t) == real(D_1) == real(D_2) == T
+        @test normals(D_t) == D_t.normals
+        @test boundary_indices(D_t) == D_t.boundary_indices
 
-        @test length(grid(D_t)) == N_x * N_y
+        nodes = grid(D_t)
+        @test length(nodes) == N_x * N_y
+        u = sin.(first.(nodes) .^ 2) .* cospi.(last.(nodes))
+        u_reference = copy(u)
+
+        SummationByPartsOperators.scale_by_mass_matrix!(u, D_t)
+        SummationByPartsOperators.scale_by_inverse_mass_matrix!(u, D_t)
+        @test u ≈ u_reference
+        @test length(restrict_interior(u, D_t)) == (N_x - 2) * (N_y - 2)
+        @test length(restrict_boundary(u, D_t)) == 2 * (N_x + N_y)
+
+        # derivative operators
         M = mass_matrix(D_t)
         D_x = D_t[1]
         @test D_x isa SparseMatrixCSC
@@ -147,6 +161,11 @@ end
         B_1D_2 = mass_matrix_boundary(D_2)
         @test B_x ≈ Diagonal(kron(B_1D_1, M_1D_2))
         @test B_y ≈ Diagonal(kron(M_1D_1, B_1D_2))
+
+        # integrals
+        @test integrate(abs2, u, D_t) ≈ sum(M * abs2.(u))
+        @test integrate_boundary(abs2, u, D_t, 1) ≈ sum(B_x * abs2.(u))
+        @test integrate_boundary(abs2, u, D_t, 2) ≈ sum(B_y * abs2.(u))
 
         # accuracy test
         x = grid(D_t)

--- a/test/multidimensional_matrix_operators_test.jl
+++ b/test/multidimensional_matrix_operators_test.jl
@@ -105,7 +105,6 @@ end
         D_2 = derivative_operator(MattssonAlmquistCarpenter2014Extended(), 1, acc_order,
                                   T(ymin_construction), T(ymax_construction), N_y)
         D_t = tensor_product_operator_2D(D_1, D_2)
-        @test kron(D_1, D_2) == D_t
 
         for compact in (true, false)
             show(IOContext(devnull, :compact => compact), D_t)

--- a/test/periodic_operators_test.jl
+++ b/test/periodic_operators_test.jl
@@ -32,6 +32,8 @@ let T = Float32
     @test issymmetric(D) == false
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -63,6 +65,8 @@ let T = Float32
     @test issymmetric(D) == false
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -98,6 +102,8 @@ let T = Float32
     @test issymmetric(D) == false
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -139,6 +145,8 @@ let T = Float32
     @test issymmetric(D) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -175,6 +183,8 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -215,6 +225,8 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -264,6 +276,8 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -295,6 +309,8 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -333,6 +349,8 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -404,6 +422,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -433,6 +453,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -466,6 +488,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -500,6 +524,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -529,6 +555,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -564,6 +592,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
     mul!(res, D, x0)
@@ -600,6 +630,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -629,6 +661,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -665,6 +699,8 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test restrict_interior(x2, D) ≈ x2
+    @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
     @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
     mul!(res, D, x0)
@@ -1084,6 +1120,8 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test restrict_interior(x2, D) ≈ x2
+        @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
         mul!(res, D, x0)
@@ -1110,6 +1148,8 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test restrict_interior(x2, D) ≈ x2
+        @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
         @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
         mul!(res, D, x0)
@@ -1153,6 +1193,8 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
+        @test restrict_interior(x2, D) ≈ x2
+        @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
         @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
         mul!(res, D, x0)
@@ -1184,6 +1226,8 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
+        @test restrict_interior(x2, D) ≈ x2
+        @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
         @test M * Matrix(D) - Matrix(D)' * M ≈ zeros(T, N, N)
         mul!(res, D, x0)
@@ -1267,6 +1311,8 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test restrict_interior(x2, D) ≈ x2
+            @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
             @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
             mul!(res, D, x0)
@@ -1303,6 +1349,8 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test restrict_interior(x2, D) ≈ x2
+            @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
             @test M * Matrix(D) + Matrix(D)' * M ≈ mass_matrix_boundary(D)
             mul!(res, D, x0)
@@ -1363,6 +1411,8 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test restrict_interior(x2, D) ≈ x2
+            @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
             @test M * Matrix(D) + Matrix(D)' * M == mass_matrix_boundary(D)
             mul!(res, D, x0)
@@ -1384,6 +1434,8 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test restrict_interior(x2, D) ≈ x2
+            @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
             @test M * Matrix(D) + Matrix(D)' * M == mass_matrix_boundary(D)
             mul!(res, D, x0)


### PR DESCRIPTION
This adds some more API especially for multidimensional matrix derivative operators, namely:

- In analogy to `restrict_boundary`, I added a function `restrict_interior`, which I found useful in one of my applications
- Add an official API for obtaining the normals and boundary_indices from an operator (also for #329)
- ~Allow usage of `Base.kron` to create a `TensorProductOperator`~

I also added some more tests.