### PR TITLE
Fix comment about location of corners in tensor product operator

### DIFF
--- a/src/tensor_product_operators.jl
+++ b/src/tensor_product_operators.jl
@@ -40,8 +40,8 @@ function mass_matrix_boundary(D::TensorProductOperator{2}, dim::Int)
     # This exploits how we construct the tensor product operator in `tensor_product_operator_2D`.
     if dim == 1
         corners_x_dir = [N_y + 1, # lower left corner
-            N_x + N_y + 1, # upper left corner
             N_x + N_y, # lower right corner
+            N_x + N_y + 1, # upper left corner
             2 * N_x + N_y] # upper right corner
         deleteat!(boundary_weights, corners_x_dir)
         deleteat!(boundary_indices, corners_x_dir)

--- a/src/tensor_product_operators.jl
+++ b/src/tensor_product_operators.jl
@@ -40,8 +40,8 @@ function mass_matrix_boundary(D::TensorProductOperator{2}, dim::Int)
     # This exploits how we construct the tensor product operator in `tensor_product_operator_2D`.
     if dim == 1
         corners_x_dir = [N_y + 1, # lower left corner
-            N_x + N_y, # upper left corner
-            N_x + N_y + 1, # lower right corner
+            N_x + N_y + 1, # upper left corner
+            N_x + N_y, # lower right corner
             2 * N_x + N_y] # upper right corner
         deleteat!(boundary_weights, corners_x_dir)
         deleteat!(boundary_indices, corners_x_dir)


### PR DESCRIPTION
This is just a very small fix of the comment explaining, which corner is located at which position. I noticed that this was actually not quite correct. In https://github.com/ranocha/SummationByPartsOperators.jl/blob/73471f9f5e941769b9809e47d14595484c85d777/src/tensor_product_operators.jl#L134-L137 we set the the boundary indices as `[left..., lower..., upper..., right...]`, which means the second lower upper corner is `N_x + N_y + 1` and the first lower right corner is `N_x + N_y`. This doesn't change anything in the results because the order of the entries doesn't matter because all of the indices will be deleted. But it doesn't confuse a potential reader.