### PR TITLE
Make tolerance less strict to fix CI

### DIFF
--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -31,7 +31,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         D = function_space_operator(basis_functions, nodes, source)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-12))
         @test D * nodes ≈ ones(N)
         @test D * exp.(nodes) ≈ exp.(nodes)
         M = mass_matrix(D)


### PR DESCRIPTION
It seems like something upstream changed, such that the tolerance of 1e-13 is a bit too strict now, which is why CI currently fail (see, e.g., [here](https://github.com/ranocha/SummationByPartsOperators.jl/actions/runs/24970658541/job/73112934011?pr=409#step:6:442)). This PR should fix this by making the tolerance less strict.
Locally I get:
```julia
julia> using SummationByPartsOperators

julia> import Optim, ForwardDiff

julia> N = 5
5

julia> x_min = -1.0
-1.0

julia> x_max = 1.0
1.0

julia> nodes = collect(range(x_min, x_max, length = N))
5-element Vector{Float64}:
 -1.0
 -0.5
  0.0
  0.5
  1.0

julia> source = GlaubitzNordströmÖffner2023()
Glaubitz, Nordström, Öffner (2023) 
  Summation-by-parts operators for general function spaces. 
  SIAM Journal on Numerical Analysis 61, 2, pp. 733-754. 
See also 
  Glaubitz, Nordström, Öffner (2025) 
  An optimization-based construction procedure for function 
    space based summation-by-parts operators on arbitrary grids. 
  Journal of Scientific Computing 105, 83.

julia> basis_functions = [one, identity, exp]
3-element Vector{Function}:
 one (generic function with 45 methods)
 identity (generic function with 1 method)
 exp (generic function with 19 methods)

julia> D = function_space_operator(basis_functions, nodes, source)
Matrix-based first-derivative operator {T=Float64} on 5 nodes in [-1.0, 1.0]

julia> all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
false

julia> all(isapprox.(D * ones(N), zeros(N); atol = 1e-12))
true

julia> D * ones(N)
5-element Vector{Float64}:
 -1.9317880628477724e-14
  7.216449660063518e-16
  1.1296519275560968e-13
 -5.440092820663267e-15
 -1.0524914273446484e-13
```