### PR TITLE
Add `isperiodic` for operators

### DIFF
--- a/src/SummationByPartsOperators.jl
+++ b/src/SummationByPartsOperators.jl
@@ -149,7 +149,8 @@ export integrate, integrate_boundary,
        derivative_left, derivative_right,
        mul_transpose_derivative_left!, mul_transpose_derivative_right!,
        evaluate_coefficients, evaluate_coefficients!,
-       compute_coefficients, compute_coefficients!
+       compute_coefficients, compute_coefficients!,
+       isperiodic
 export periodic_central_derivative_operator, periodic_derivative_operator,
        derivative_operator,
        dissipation_operator, var_coef_derivative_operator,

--- a/src/general_operators.jl
+++ b/src/general_operators.jl
@@ -146,6 +146,14 @@ end
 @inline grid(D::AbstractDerivativeOperator) = D.grid
 @inline grid(D::AbstractPeriodicDerivativeOperator) = D.grid_compute
 
+"""
+    isperiodic(D)
+
+Return `true` if the derivative operator `D` is periodic and `false` otherwise.
+"""
+isperiodic(D::AbstractDerivativeOperator) = false
+isperiodic(D::AbstractPeriodicDerivativeOperator) = true
+
 xmin(D::AbstractDerivativeOperator) = first(grid(D))
 xmax(D::AbstractDerivativeOperator) = last(grid(D))
 

--- a/test/SBP_operators_test.jl
+++ b/test/SBP_operators_test.jl
@@ -40,7 +40,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -111,7 +111,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -192,7 +192,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -283,7 +283,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -382,7 +382,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -448,7 +448,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -523,7 +523,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -605,7 +605,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -698,7 +698,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -763,7 +763,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -837,7 +837,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -925,7 +925,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -998,7 +998,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -1082,7 +1082,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]

--- a/test/SBP_operators_test.jl
+++ b/test/SBP_operators_test.jl
@@ -40,6 +40,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -110,6 +111,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -190,6 +192,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -280,6 +283,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -378,6 +382,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -443,6 +448,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -517,6 +523,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -598,6 +605,7 @@ for source in D_test_list, T in (Float32, Float64)
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         # SBP property
@@ -690,6 +698,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -754,6 +763,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -827,6 +837,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -914,6 +925,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -986,6 +998,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]
@@ -1069,6 +1082,7 @@ end
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
 
         @test restrict_interior(x2, D) ≈ x2[(begin + 1):(end - 1)]
         @test restrict_boundary(x2, D) ≈ [xmin^2, xmax^2]

--- a/test/legendre_operators_test.jl
+++ b/test/legendre_operators_test.jl
@@ -23,6 +23,7 @@ for T in (Float32, Float64)
         println(devnull, D)
         @test SummationByPartsOperators.derivative_order(D) == 1
         @test issymmetric(D) == false
+        @test isperiodic(D) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         M = mass_matrix(D)

--- a/test/legendre_operators_test.jl
+++ b/test/legendre_operators_test.jl
@@ -23,7 +23,7 @@ for T in (Float32, Float64)
         println(devnull, D)
         @test SummationByPartsOperators.derivative_order(D) == 1
         @test issymmetric(D) == false
-        @test isperiodic(D) == false
+        @test @inferred(isperiodic(D)) == false
         @test SummationByPartsOperators.xmin(D) ≈ xmin
         @test SummationByPartsOperators.xmax(D) ≈ xmax
         M = mass_matrix(D)

--- a/test/matrix_operators_test.jl
+++ b/test/matrix_operators_test.jl
@@ -55,6 +55,9 @@ using SummationByPartsOperators
         @test issymmetric(Dm) == false
         @test issymmetric(Dp) == false
         @test issymmetric(Dc) == false
+        @test isperiodic(Dm) == false
+        @test isperiodic(Dp) == false
+        @test isperiodic(Dc) == false
 
         D_reference = upwind_operators(Mattsson2017;
                                        derivative_order = 1, accuracy_order = acc_order,
@@ -175,6 +178,9 @@ end
         @test issymmetric(Dm) == false
         @test issymmetric(Dp) == false
         @test issymmetric(Dc) == false
+        @test isperiodic(Dm) == false
+        @test isperiodic(Dp) == false
+        @test isperiodic(Dc) == false
 
         D_reference = upwind_operators(Mattsson2017;
                                        derivative_order = 1, accuracy_order = acc_order,

--- a/test/matrix_operators_test.jl
+++ b/test/matrix_operators_test.jl
@@ -55,9 +55,9 @@ using SummationByPartsOperators
         @test issymmetric(Dm) == false
         @test issymmetric(Dp) == false
         @test issymmetric(Dc) == false
-        @test isperiodic(Dm) == false
-        @test isperiodic(Dp) == false
-        @test isperiodic(Dc) == false
+        @test @inferred(isperiodic(Dm)) == false
+        @test @inferred(isperiodic(Dp)) == false
+        @test @inferred(isperiodic(Dc)) == false
 
         D_reference = upwind_operators(Mattsson2017;
                                        derivative_order = 1, accuracy_order = acc_order,
@@ -178,9 +178,9 @@ end
         @test issymmetric(Dm) == false
         @test issymmetric(Dp) == false
         @test issymmetric(Dc) == false
-        @test isperiodic(Dm) == false
-        @test isperiodic(Dp) == false
-        @test isperiodic(Dc) == false
+        @test @inferred(isperiodic(Dm)) == false
+        @test @inferred(isperiodic(Dp)) == false
+        @test @inferred(isperiodic(Dc)) == false
 
         D_reference = upwind_operators(Mattsson2017;
                                        derivative_order = 1, accuracy_order = acc_order,

--- a/test/periodic_operators_test.jl
+++ b/test/periodic_operators_test.jl
@@ -30,6 +30,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -63,6 +64,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -100,6 +102,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -143,6 +146,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -183,6 +187,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -225,6 +230,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -276,6 +282,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -309,6 +316,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -349,6 +357,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -422,6 +431,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -453,6 +463,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -488,6 +499,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -524,6 +536,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -555,6 +568,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -592,6 +606,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -630,6 +645,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -661,6 +677,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -699,6 +716,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
+    @test isperiodic(D) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -1120,6 +1138,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1148,6 +1167,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
+        @test isperiodic(D) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1193,6 +1213,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
+        @test isperiodic(D) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1226,6 +1247,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
+        @test isperiodic(D) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1311,6 +1333,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test isperiodic(D) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1349,6 +1372,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test isperiodic(D) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1411,6 +1435,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test isperiodic(D) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1434,6 +1459,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
+            @test isperiodic(D) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)

--- a/test/periodic_operators_test.jl
+++ b/test/periodic_operators_test.jl
@@ -30,7 +30,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -64,7 +64,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -102,7 +102,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -146,7 +146,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test SummationByPartsOperators.xmin(D) ≈ xmin
     @test SummationByPartsOperators.xmax(D) ≈ xmax
     @test restrict_interior(x2, D) ≈ x2
@@ -187,7 +187,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -230,7 +230,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -282,7 +282,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -316,7 +316,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -357,7 +357,7 @@ let T = Float32
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -431,7 +431,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -463,7 +463,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -499,7 +499,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -536,7 +536,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -568,7 +568,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -606,7 +606,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -645,7 +645,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == true # because this operator is zero!
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -677,7 +677,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -716,7 +716,7 @@ let T = Float64
     @test SummationByPartsOperators.derivative_order(D) == derivative_order
     @test SummationByPartsOperators.accuracy_order(D) == accuracy_order
     @test issymmetric(D) == false
-    @test isperiodic(D) == true
+    @test @inferred(isperiodic(D)) == true
     @test restrict_interior(x2, D) ≈ x2
     @test length(restrict_boundary(x2, D)) == 0
     M = mass_matrix(D)
@@ -1138,7 +1138,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == true
+        @test @inferred(isperiodic(D)) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1167,7 +1167,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == false
-        @test isperiodic(D) == true
+        @test @inferred(isperiodic(D)) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1213,7 +1213,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
-        @test isperiodic(D) == true
+        @test @inferred(isperiodic(D)) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1247,7 +1247,7 @@ let T = Float32
         @test derivative_order(D) == der_order
         @test accuracy_order(D) == acc_order
         @test issymmetric(D) == true
-        @test isperiodic(D) == true
+        @test @inferred(isperiodic(D)) == true
         @test restrict_interior(x2, D) ≈ x2
         @test length(restrict_boundary(x2, D)) == 0
         M = mass_matrix(D)
@@ -1333,7 +1333,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
-            @test isperiodic(D) == true
+            @test @inferred(isperiodic(D)) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1372,7 +1372,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
-            @test isperiodic(D) == true
+            @test @inferred(isperiodic(D)) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1435,7 +1435,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
-            @test isperiodic(D) == true
+            @test @inferred(isperiodic(D)) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)
@@ -1459,7 +1459,7 @@ end
             @test derivative_order(D) == der_order
             @test accuracy_order(D) == acc_order
             @test issymmetric(D) == false
-            @test isperiodic(D) == true
+            @test @inferred(isperiodic(D)) == true
             @test restrict_interior(x2, D) ≈ x2
             @test length(restrict_boundary(x2, D)) == 0
             M = mass_matrix(D)

--- a/test/upwind_operators_test.jl
+++ b/test/upwind_operators_test.jl
@@ -25,6 +25,9 @@ D_test_list = vcat([(Mattsson2017, acc_order) for acc_order in 2:9],
             summary(IOContext(devnull, :compact => compact), Dm_bounded)
             summary(IOContext(devnull, :compact => compact), Dc_bounded)
         end
+        @test isperiodic(Dp_bounded) == false
+        @test isperiodic(Dm_bounded) == false
+        @test isperiodic(Dc_bounded) == false
         M = mass_matrix(Dp_bounded)
         @test M == mass_matrix(Dm_bounded)
         @test M == mass_matrix(Dc_bounded)
@@ -83,6 +86,7 @@ D_test_list = vcat([(Mattsson2017, acc_order) for acc_order in 2:9],
         D_periodic = upwind_operators(periodic_derivative_operator;
                                       accuracy_order = acc_order,
                                       xmin, xmax, N = N - 1)
+        @test isperiodic(D_periodic) == true
         @test D_periodic.minus == Dm_periodic
         @test D_periodic.plus == Dp_periodic
         @test Matrix(D_periodic.central) ≈ (Matrix(Dm_periodic) + Matrix(Dp_periodic)) / 2
@@ -237,6 +241,11 @@ end
     @test size(D.plus) == (12, 12)
     @test size(D.central) == (12, 12)
 
+    @test isperiodic(D) == false
+    @test isperiodic(D.minus) == false
+    @test isperiodic(D.plus) == false
+    @test isperiodic(D.central) == false
+
     x = @inferred grid(D)
     u = @. sinpi(2 * x)
 
@@ -282,6 +291,11 @@ end
     @test size(D.minus) == (12, 12)
     @test size(D.plus) == (12, 12)
     @test size(D.central) == (12, 12)
+
+    @test isperiodic(D) == true
+    @test isperiodic(D.minus) == true
+    @test isperiodic(D.plus) == true
+    @test isperiodic(D.central) == true
 
     x = @inferred grid(D)
     u = @. sinpi(2 * x)

--- a/test/upwind_operators_test.jl
+++ b/test/upwind_operators_test.jl
@@ -25,9 +25,9 @@ D_test_list = vcat([(Mattsson2017, acc_order) for acc_order in 2:9],
             summary(IOContext(devnull, :compact => compact), Dm_bounded)
             summary(IOContext(devnull, :compact => compact), Dc_bounded)
         end
-        @test isperiodic(Dp_bounded) == false
-        @test isperiodic(Dm_bounded) == false
-        @test isperiodic(Dc_bounded) == false
+        @test @inferred(isperiodic(Dp_bounded)) == false
+        @test @inferred(isperiodic(Dm_bounded)) == false
+        @test @inferred(isperiodic(Dc_bounded)) == false
         M = mass_matrix(Dp_bounded)
         @test M == mass_matrix(Dm_bounded)
         @test M == mass_matrix(Dc_bounded)
@@ -86,7 +86,7 @@ D_test_list = vcat([(Mattsson2017, acc_order) for acc_order in 2:9],
         D_periodic = upwind_operators(periodic_derivative_operator;
                                       accuracy_order = acc_order,
                                       xmin, xmax, N = N - 1)
-        @test isperiodic(D_periodic) == true
+        @test @inferred(isperiodic(D_periodic)) == true
         @test D_periodic.minus == Dm_periodic
         @test D_periodic.plus == Dp_periodic
         @test Matrix(D_periodic.central) ≈ (Matrix(Dm_periodic) + Matrix(Dp_periodic)) / 2
@@ -241,10 +241,10 @@ end
     @test size(D.plus) == (12, 12)
     @test size(D.central) == (12, 12)
 
-    @test isperiodic(D) == false
-    @test isperiodic(D.minus) == false
-    @test isperiodic(D.plus) == false
-    @test isperiodic(D.central) == false
+    @test @inferred(isperiodic(D)) == false
+    @test @inferred(isperiodic(D.minus)) == false
+    @test @inferred(isperiodic(D.plus)) == false
+    @test @inferred(isperiodic(D.central)) == false
 
     x = @inferred grid(D)
     u = @. sinpi(2 * x)
@@ -292,10 +292,10 @@ end
     @test size(D.plus) == (12, 12)
     @test size(D.central) == (12, 12)
 
-    @test isperiodic(D) == true
-    @test isperiodic(D.minus) == true
-    @test isperiodic(D.plus) == true
-    @test isperiodic(D.central) == true
+    @test @inferred(isperiodic(D)) == true
+    @test @inferred(isperiodic(D.minus)) == true
+    @test @inferred(isperiodic(D.plus)) == true
+    @test @inferred(isperiodic(D.central)) == true
 
     x = @inferred grid(D)
     u = @. sinpi(2 * x)


### PR DESCRIPTION
Sometimes I would like to know if an operator is periodic and it is more convenient with a trait `isperiodic` than checking something like `D isa AbstractPeriodicDerivativeOperator`. In my use case I have a function where large parts of it works for periodic and non-periodic SBP operators, but differs in one part of the function. So I would like to distinguish. `isperiodic` is already defined for meshes in SummationByPartsOperators.jl, so I think it would be reasonable to also define it for operators.