### PR TITLE
Fix CI related to LineSearches.jl

### DIFF
--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -44,8 +44,9 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         0.8574665549914025, 1.0]
     N = length(nodes)
     let basis_functions = [one, identity, exp]
-        D = function_space_operator(basis_functions, nodes, source,
-                                    options = Optim.Options(g_tol = 1e-15, iterations = 15000))
+        D = function_space_operator(basis_functions, nodes, source, verbose = true,
+                                    options = Optim.Options(g_tol = 1e-15,
+                                                            iterations = 15000))
 
         @test grid(D) ≈ nodes
         @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-11))

--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -44,7 +44,8 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         0.8574665549914025, 1.0]
     N = length(nodes)
     let basis_functions = [one, identity, exp]
-        D = function_space_operator(basis_functions, nodes, source)
+        D = function_space_operator(basis_functions, nodes, source,
+                                    options = Optim.Options(g_tol = 1e-15, iterations = 15000))
 
         @test grid(D) ≈ nodes
         @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-11))

--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -46,7 +46,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
     let basis_functions = [one, identity, exp]
         D = function_space_operator(basis_functions, nodes, source, verbose = true,
                                     options = Optim.Options(g_tol = 1e-15,
-                                                            iterations = 15000))
+                                                            iterations = 25000))
 
         @test grid(D) ≈ nodes
         @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-11))


### PR DESCRIPTION
This should fix CI as observed in https://github.com/ranocha/SummationByPartsOperators.jl/pull/413#issuecomment-4555316434. I verified locally that under LineSearches.jl v7.6.1 the tests pass, but with v7.6.2 they fail. It looks like the optimization needs significantly more iterations to properly converge, cf.
With LineSearches.jl v7.6.1:
```julia
julia> D = function_space_operator(basis_functions, nodes, source,
                                   verbose = true)
 * Status: success

 * Candidate solution
    Final objective value:     3.375528e-26

 * Found with
    Algorithm:     L-BFGS

 * Convergence measures
    |x - x'|               = 3.31e-09 ≰ 0.0e+00
    |x - x'|/|x'|          = 7.80e-10 ≰ 0.0e+00
    |f(x) - f(x')|         = 1.92e-27 ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = 5.70e-02 ≰ 0.0e+00
    |g(x)|                 = 6.35e-15 ≤ 1.0e-14

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    4309
    f(x) calls:    10999
    ∇f(x) calls:   10999
    ∇f(x)ᵀv calls: 0

Matrix-based first-derivative operator {T=Float64} on 10 nodes in [0.0, 1.0]
```

With LineSearches.jl v7.6.2:
```julia
julia> D = function_space_operator(basis_functions, nodes, source,
                                   verbose = true)
 * Status: failure (reached maximum number of iterations)

 * Candidate solution
    Final objective value:     2.768931e-13

 * Found with
    Algorithm:     L-BFGS

 * Convergence measures
    |x - x'|               = 3.47e-05 ≰ 0.0e+00
    |x - x'|/|x'|          = 9.41e-06 ≰ 0.0e+00
    |f(x) - f(x')|         = 8.51e-17 ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = 3.07e-04 ≰ 0.0e+00
    |g(x)|                 = 4.01e-09 ≰ 1.0e-14

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    10000
    f(x) calls:    10685
    ∇f(x) calls:   10685
    ∇f(x)ᵀv calls: 0

Matrix-based first-derivative operator {T=Float64} on 10 nodes in [0.0, 1.0]

julia> D = function_space_operator(basis_functions, nodes, source,
                                   verbose = true, options = Optim.Options(g_tol = 1e-15, iterations = 15000))
 * Status: success

 * Candidate solution
    Final objective value:     3.081928e-28

 * Found with
    Algorithm:     L-BFGS

 * Convergence measures
    |x - x'|               = 4.79e-11 ≰ 0.0e+00
    |x - x'|/|x'|          = 1.23e-11 ≰ 0.0e+00
    |f(x) - f(x')|         = 1.54e-29 ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = 4.98e-02 ≰ 0.0e+00
    |g(x)|                 = 8.78e-16 ≤ 1.0e-15

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    12395
    f(x) calls:    13251
    ∇f(x) calls:   13251
    ∇f(x)ᵀv calls: 0

Matrix-based first-derivative operator {T=Float64} on 10 nodes in [0.0, 1.0]
```
This is annoying. I'll see if I (or AI...) can fix the issue in LineSearches.jl.