### PR TITLE
Use `BFGS` as default in optimization for function space operators

### DIFF
--- a/ext/SummationByPartsOperatorsOptimForwardDiffExt.jl
+++ b/ext/SummationByPartsOperatorsOptimForwardDiffExt.jl
@@ -1,6 +1,6 @@
 module SummationByPartsOperatorsOptimForwardDiffExt
 
-using Optim: Optim, Options, LBFGS, optimize, minimizer
+using Optim: Optim, Options, BFGS, optimize, minimizer
 using ForwardDiff: ForwardDiff
 
 using SummationByPartsOperators: SummationByPartsOperators, GlaubitzNordströmÖffner2023,
@@ -13,7 +13,7 @@ function SummationByPartsOperators.function_space_operator(basis_functions,
                                                            source::SourceOfCoefficients;
                                                            derivative_order = 1,
                                                            accuracy_order = 0,
-                                                           opt_alg = LBFGS(),
+                                                           opt_alg = BFGS(),
                                                            options = Options(g_tol = 1e-14,
                                                                              iterations = 10000),
                                                            verbose = false) where {T,

--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -19,7 +19,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
                                                            source; derivative_order = 2)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-14))
         @test D * nodes ≈ ones(N)
         @test D * (nodes .^ 2) ≈ 2 * nodes
         @test D * (nodes .^ 3) ≈ 3 * (nodes .^ 2)
@@ -31,7 +31,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         D = function_space_operator(basis_functions, nodes, source)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-12))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
         @test D * nodes ≈ ones(N)
         @test D * exp.(nodes) ≈ exp.(nodes)
         M = mass_matrix(D)
@@ -44,12 +44,10 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         0.8574665549914025, 1.0]
     N = length(nodes)
     let basis_functions = [one, identity, exp]
-        D = function_space_operator(basis_functions, nodes, source, verbose = true,
-                                    options = Optim.Options(g_tol = 1e-15,
-                                                            iterations = 25000))
+        D = function_space_operator(basis_functions, nodes, source, verbose = true)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-11))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
         @test D * nodes ≈ ones(N)
         @test D * exp.(nodes) ≈ exp.(nodes)
         M = mass_matrix(D)

--- a/test/function_space_operators_test.jl
+++ b/test/function_space_operators_test.jl
@@ -19,7 +19,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
                                                            source; derivative_order = 2)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-14))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
         @test D * nodes ≈ ones(N)
         @test D * (nodes .^ 2) ≈ 2 * nodes
         @test D * (nodes .^ 3) ≈ 3 * (nodes .^ 2)
@@ -47,7 +47,7 @@ import Optim, ForwardDiff # to enable loading the function space operator optimi
         D = function_space_operator(basis_functions, nodes, source, verbose = true)
 
         @test grid(D) ≈ nodes
-        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-13))
+        @test all(isapprox.(D * ones(N), zeros(N); atol = 1e-12))
         @test D * nodes ≈ ones(N)
         @test D * exp.(nodes) ≈ exp.(nodes)
         M = mass_matrix(D)


### PR DESCRIPTION
As discussed in #415 (I also noticed this already some time ago, but never updated the default here), `BFGS` usually performs better than `LBFGS` for us at least for the smaller to medium size problems. In the tests it usually converges faster than `LBFGS` both in terms of iteration count and function evaluations, it runs also faster, and usually often even converges to a slightly smaller minimum. The latter even allows us to use slightly tighter tolerances in the tests.
I did not change the default `linesearch` algorithm because for `BFGS` the difference between them is not as strong as for `LBFGS` and it would require us to put LineSearches.jl into the extension (we could do that because it would automatically be loaded since Optim.jl loads it, but IMO it would not be so nice).
Since this feature is marked as experimental
https://github.com/ranocha/SummationByPartsOperators.jl/blob/ede5990be1c614f8d430e90f905ffb4738f1f433/src/function_space_operators.jl#L61-L62
I think it is fine to change the default.

Closes #415.