### PR TITLE
Only check for approximate equality for grid in `UpwindOperators`

### DIFF
--- a/src/upwind_operators.jl
+++ b/src/upwind_operators.jl
@@ -37,7 +37,7 @@ See also [`upwind_operators`](@ref), [`PeriodicUpwindOperators`](@ref)
                                                 AbstractNonperiodicDerivativeOperator{T},
                                                 Plus <:
                                                 AbstractNonperiodicDerivativeOperator{T}}
-        @argcheck grid(minus) == grid(central) == grid(plus)
+        @argcheck grid(minus) ≈ grid(central) ≈ grid(plus)
         @argcheck size(minus) == size(central) == size(plus)
         @argcheck derivative_order(minus) == derivative_order(central) ==
                   derivative_order(plus)
@@ -90,7 +90,7 @@ See also [`upwind_operators`](@ref), [`UpwindOperators`](@ref)
                                                         Plus <:
                                                         AbstractPeriodicDerivativeOperator{T}
                                                         }
-        @argcheck grid(minus) == grid(central) == grid(plus)
+        @argcheck grid(minus) ≈ grid(central) ≈ grid(plus)
         @argcheck size(minus) == size(central) == size(plus)
         @argcheck derivative_order(minus) == derivative_order(central) ==
                   derivative_order(plus)

--- a/test/upwind_operators_test.jl
+++ b/test/upwind_operators_test.jl
@@ -335,10 +335,13 @@ end
 end
 
 @testset "grid equality check (#419)" begin
-    xmin = -1.0; xmax = 1.0
+    xmin = -1.0
+    xmax = 1.0
     D_GLL = legendre_derivative_operator(xmin, xmax, 4)
     weights = diag(mass_matrix(D_GLL))
-    Dm = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0, nothing)
-    Dp = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0, nothing)
+    Dm = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0,
+                                  nothing)
+    Dp = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0,
+                                  nothing)
     @test_nowarn UpwindOperators(Dm, D_GLL, Dp)
 end

--- a/test/upwind_operators_test.jl
+++ b/test/upwind_operators_test.jl
@@ -188,15 +188,15 @@ end
     M = mass_matrix(D)
     @test M * Matrix(Dp) + Matrix(Dm)' * M ≈ mass_matrix_boundary(D)
 
-    @test_throws ArgumentError UpwindOperators(derivative_operator(Mattsson2017(:minus), 1,
-                                                                   acc_order, xmin, xmax,
-                                                                   N),
-                                               derivative_operator(Mattsson2017(:central),
-                                                                   1, acc_order, xmin, xmax,
-                                                                   N + 1),
-                                               derivative_operator(Mattsson2017(:plus), 1,
-                                                                   acc_order, xmin, xmax,
-                                                                   N))
+    @test_throws DimensionMismatch UpwindOperators(derivative_operator(Mattsson2017(:minus),
+                                                                       1, acc_order,
+                                                                       xmin, xmax, N),
+                                                   derivative_operator(Mattsson2017(:central),
+                                                                       1, acc_order,
+                                                                       xmin, xmax, N + 1),
+                                                   derivative_operator(Mattsson2017(:plus),
+                                                                       1, acc_order,
+                                                                       xmin, xmax, N))
 
     # mass matrix scaling
     x1 = grid(D)

--- a/test/upwind_operators_test.jl
+++ b/test/upwind_operators_test.jl
@@ -333,3 +333,12 @@ end
         summary(IOContext(devnull, :compact => compact), D.central)
     end
 end
+
+@testset "grid equality check (#419)" begin
+    xmin = -1.0; xmax = 1.0
+    D_GLL = legendre_derivative_operator(xmin, xmax, 4)
+    weights = diag(mass_matrix(D_GLL))
+    Dm = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0, nothing)
+    Dp = MatrixDerivativeOperator(xmin, xmax, grid(D_GLL), weights, Matrix(D_GLL), 0, nothing)
+    @test_nowarn UpwindOperators(Dm, D_GLL, Dp)
+end


### PR DESCRIPTION
Sometimes there are small differences (in the order of machine precision) of the `grid` when trying to construct upwind operators via `UpwindOperators`, e.g., due to multiplications with Jacobians. However, since `UpwindOperators` checks for exact equality of `grid` for all three parts, the construction fails. I changed it to only test approximate equality and added a test, which failed before.